### PR TITLE
Qt 5 Support for MUtilities

### DIFF
--- a/include/MUtils/OSSupport.h
+++ b/include/MUtils/OSSupport.h
@@ -28,6 +28,7 @@
 #include <QString>
 #include <QMap>
 #include <QDate>
+#include <QWidget>
 
 //Forward declaration
 class QFile;

--- a/src/GUI.cpp
+++ b/src/GUI.cpp
@@ -92,7 +92,7 @@ namespace MUtils
 					QObject(parent),
 					m_hIcon(hIcon)
 				{
-					SendMessage(parent->winId(), WM_SETICON, (bIsBigIcon ? ICON_BIG : ICON_SMALL), LPARAM(hIcon));
+					SendMessage(reinterpret_cast<HWND>(parent->winId()), WM_SETICON, (bIsBigIcon ? ICON_BIG : ICON_SMALL), LPARAM(hIcon));
 				}
 
 				virtual ~WindowIconHelper(void)

--- a/src/GUI_Win32.cpp
+++ b/src/GUI_Win32.cpp
@@ -88,7 +88,7 @@ bool MUtils::GUI::sysmenu_append(const QWidget *win, const unsigned int identifi
 {
 	bool ok = false;
 	
-	if(HMENU hMenu = GetSystemMenu(win->winId(), FALSE))
+	if(HMENU hMenu = GetSystemMenu(reinterpret_cast<HWND>(win->winId()), FALSE))
 	{
 		ok = (AppendMenuW(hMenu, MF_SEPARATOR, 0, 0) == TRUE);
 		ok = (AppendMenuW(hMenu, MF_STRING, identifier, MUTILS_WCHR(text)) == TRUE);
@@ -101,7 +101,7 @@ bool MUtils::GUI::sysmenu_update(const QWidget *win, const unsigned int identifi
 {
 	bool ok = false;
 	
-	if(HMENU hMenu = ::GetSystemMenu(win->winId(), FALSE))
+	if(HMENU hMenu = ::GetSystemMenu(reinterpret_cast<HWND>(win->winId()), FALSE))
 	{
 		ok = (ModifyMenu(hMenu, identifier, MF_STRING | MF_BYCOMMAND, identifier, MUTILS_WCHR(text)) == TRUE);
 	}
@@ -121,7 +121,7 @@ bool MUtils::GUI::enable_close_button(const QWidget *win, const bool &bEnable)
 {
 	bool ok = false;
 
-	if(HMENU hMenu = GetSystemMenu(win->winId(), FALSE))
+	if(HMENU hMenu = GetSystemMenu(reinterpret_cast<HWND>(win->winId()), FALSE))
 	{
 		ok = (EnableMenuItem(hMenu, SC_CLOSE, MF_BYCOMMAND | (bEnable ? MF_ENABLED : MF_GRAYED)) == TRUE);
 	}
@@ -156,8 +156,8 @@ bool MUtils::GUI::bring_to_front(const QWidget *window)
 	{
 		for(int i = 0; (i < 5) && (!ret); i++)
 		{
-			ret = (SetForegroundWindow(window->winId()) != FALSE);
-			SwitchToThisWindow(window->winId(), TRUE);
+			ret = (SetForegroundWindow(reinterpret_cast<HWND>(window->winId())) != FALSE);
+			SwitchToThisWindow(reinterpret_cast<HWND>(window->winId()), TRUE);
 		}
 		LockSetForegroundWindow(LSFW_LOCK);
 	}
@@ -204,7 +204,7 @@ bool MUtils::GUI::sheet_of_glass(QWidget *const window)
 
 	//Enable the "sheet of glass" effect on this window
 	MARGINS margins = {-1, -1, -1, -1};
-	if(HRESULT hr = dwmExtendFrameIntoClientAreaFun(window->winId(), &margins))
+	if(HRESULT hr = dwmExtendFrameIntoClientAreaFun(reinterpret_cast<HWND>(window->winId()), &margins))
 	{
 		qWarning("DwmExtendFrameIntoClientArea function has failed! (error %d)", hr);
 		return false;
@@ -215,7 +215,7 @@ bool MUtils::GUI::sheet_of_glass(QWidget *const window)
 	memset(&bb, 0, sizeof(DWM_BLURBEHIND));
 	bb.fEnable = TRUE;
 	bb.dwFlags = DWM_BB_ENABLE;
-	if(HRESULT hr = dwmEnableBlurBehindWindowFun(window->winId(), &bb))
+	if(HRESULT hr = dwmEnableBlurBehindWindowFun(reinterpret_cast<HWND>(window->winId()), &bb))
 	{
 		qWarning("DwmEnableBlurBehindWindow function has failed! (error %d)", hr);
 		return false;
@@ -258,7 +258,7 @@ bool MUtils::GUI::sheet_of_glass_update(QWidget *const window)
 	memset(&bb, 0, sizeof(DWM_BLURBEHIND));
 	bb.fEnable = TRUE;
 	bb.dwFlags = DWM_BB_ENABLE;
-	if(HRESULT hr = dwmEnableBlurBehindWindowFun(window->winId(), &bb))
+	if(HRESULT hr = dwmEnableBlurBehindWindowFun(reinterpret_cast<HWND>(window->winId()), &bb))
 	{
 		qWarning("DwmEnableBlurBehindWindow function has failed! (error %d)", hr);
 		return false;

--- a/src/OSSupport_Win32.cpp
+++ b/src/OSSupport_Win32.cpp
@@ -1236,7 +1236,7 @@ bool MUtils::OS::free_diskspace(const QString &path, quint64 &freeSpace)
 
 bool MUtils::OS::shell_open(const QWidget *parent, const QString &url, const QString &parameters, const QString &directory, const bool explore)
 {
-	return ((int) ShellExecuteW((parent ? parent->winId() : NULL), (explore ? L"explore" : L"open"), MUTILS_WCHR(url), ((!parameters.isEmpty()) ? MUTILS_WCHR(parameters) : NULL), ((!directory.isEmpty()) ? MUTILS_WCHR(directory) : NULL), SW_SHOW)) > 32;
+	return ((int) ShellExecuteW((parent ? reinterpret_cast<HWND>(parent->winId()) : NULL), (explore ? L"explore" : L"open"), MUTILS_WCHR(url), ((!parameters.isEmpty()) ? MUTILS_WCHR(parameters) : NULL), ((!directory.isEmpty()) ? MUTILS_WCHR(directory) : NULL), SW_SHOW)) > 32;
 }
 
 bool MUtils::OS::shell_open(const QWidget *parent, const QString &url, const bool explore)

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -102,34 +102,34 @@ namespace MUtils
 #if QT_VERSION >= 0x050000
 static void qt_message_handler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
-    Q_UNUSED(context);
+	Q_UNUSED(context);
 
-    if (msg.isEmpty())
-    {
-        return;
-    }
+	if (msg.isEmpty())
+	{
+		return;
+	}
 
-    MUtils::Terminal::write(type, msg.toLocal8Bit().constData());
+	MUtils::Terminal::write(type, msg.toLocal8Bit().constData());
 
-    if ((type == QtCriticalMsg) || (type == QtFatalMsg))
-    {
-        MUtils::OS::fatal_exit(MUTILS_WCHR(msg));
-    }
+	if ((type == QtCriticalMsg) || (type == QtFatalMsg))
+	{
+		MUtils::OS::fatal_exit(MUTILS_WCHR(msg));
+	}
 }
 #else
 static void qt_message_handler(QtMsgType type, const char *const msg)
 {
-    if ((!msg) || (!(msg[0])))
-    {
-        return;
-    }
+	if ((!msg) || (!(msg[0])))
+	{
+		return;
+	}
 
-    MUtils::Terminal::write(type, msg);
+	MUtils::Terminal::write(type, msg);
 
-    if ((type == QtCriticalMsg) || (type == QtFatalMsg))
-    {
-        MUtils::OS::fatal_exit(MUTILS_WCHR(QString::fromUtf8(msg)));
-    }
+	if ((type == QtCriticalMsg) || (type == QtFatalMsg))
+	{
+		MUtils::OS::fatal_exit(MUTILS_WCHR(QString::fromUtf8(msg)));
+	}
 }
 #endif
 
@@ -137,26 +137,26 @@ static void qt_message_handler(QtMsgType type, const char *const msg)
 #if QT_VERSION >= 0x050000
 namespace MUtils
 {
-    namespace Startup
-    {
-        namespace Internal
-        {
-            class NativeEventFilter : public QAbstractNativeEventFilter
-            {
-            public:
-                bool nativeEventFilter(const QByteArray &eventType, void *message, long *result) Q_DECL_OVERRIDE
-                {
-                    Q_UNUSED(eventType);
-                    return MUtils::OS::handle_os_message(message, result);
-                };
-            };
-        }
-    }
+	namespace Startup
+	{
+		namespace Internal
+		{
+			class NativeEventFilter : public QAbstractNativeEventFilter
+			{
+			public:
+				bool nativeEventFilter(const QByteArray &eventType, void *message, long *result) Q_DECL_OVERRIDE
+				{
+					Q_UNUSED(eventType);
+					return MUtils::OS::handle_os_message(message, result);
+				};
+			};
+		}
+	}
 }
 #else
 static bool qt_event_filter(void *message, long *result)
 {
-    return MUtils::OS::handle_os_message(message, result);
+	return MUtils::OS::handle_os_message(message, result);
 }
 #endif
 
@@ -169,7 +169,7 @@ static int startup_main(int &argc, char **argv, MUtils::Startup::main_function_t
 #if QT_VERSION >= 0x050000
 	qInstallMessageHandler(qt_message_handler);
 #else
-    qInstallMsgHandler(qt_message_handler);
+	qInstallMsgHandler(qt_message_handler);
 #endif
 	MUtils::Terminal::setup(argc, argv, appName, MUTILS_DEBUG || debugConsole);
 	return entry_point(argc, argv);
@@ -347,8 +347,8 @@ QApplication *MUtils::Startup::create_qt(int &argc, char **argv, const QString &
 	application->setOrganizationName("LoRd_MuldeR");
 	application->setOrganizationDomain("mulder.at.gg");
 #if QT_VERSION >= 0x050000
-    MUtils::Startup::Internal::NativeEventFilter filter;
-    application->installNativeEventFilter(&filter);
+	MUtils::Startup::Internal::NativeEventFilter filter;
+	application->installNativeEventFilter(&filter);
 #else
 	application->setEventFilter(qt_event_filter);
 #endif

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -37,6 +37,9 @@
 #include <QFont>
 #include <QMessageBox>
 #include <QtPlugin>
+#if QT_VERSION >= 0x050000
+#include <QAbstractNativeEventFilter>
+#endif
 
 //CRT
 #include <string.h>
@@ -96,25 +99,66 @@ namespace MUtils
 // MESSAGE HANDLER
 ///////////////////////////////////////////////////////////////////////////////
 
+#if QT_VERSION >= 0x050000
+static void qt_message_handler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
+{
+    Q_UNUSED(context);
+
+    if (msg.isEmpty())
+    {
+        return;
+    }
+
+    MUtils::Terminal::write(type, msg.toLocal8Bit().constData());
+
+    if ((type == QtCriticalMsg) || (type == QtFatalMsg))
+    {
+        MUtils::OS::fatal_exit(MUTILS_WCHR(msg));
+    }
+}
+#else
 static void qt_message_handler(QtMsgType type, const char *const msg)
 {
-	if((!msg) || (!(msg[0])))
-	{
-		return;
-	}
+    if ((!msg) || (!(msg[0])))
+    {
+        return;
+    }
 
-	MUtils::Terminal::write(type, msg);
+    MUtils::Terminal::write(type, msg);
 
-	if((type == QtCriticalMsg) || (type == QtFatalMsg))
-	{
-		MUtils::OS::fatal_exit(MUTILS_WCHR(QString::fromUtf8(msg)));
-	}
+    if ((type == QtCriticalMsg) || (type == QtFatalMsg))
+    {
+        MUtils::OS::fatal_exit(MUTILS_WCHR(QString::fromUtf8(msg)));
+    }
 }
+#endif
 
+
+#if QT_VERSION >= 0x050000
+namespace MUtils
+{
+    namespace Startup
+    {
+        namespace Internal
+        {
+            class NativeEventFilter : public QAbstractNativeEventFilter
+            {
+            public:
+                bool nativeEventFilter(const QByteArray &eventType, void *message, long *result) Q_DECL_OVERRIDE
+                {
+                    Q_UNUSED(eventType);
+                    return MUtils::OS::handle_os_message(message, result);
+                };
+            };
+        }
+    }
+}
+#else
 static bool qt_event_filter(void *message, long *result)
 {
-	return MUtils::OS::handle_os_message(message, result);
+    return MUtils::OS::handle_os_message(message, result);
 }
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // STARTUP FUNCTION
@@ -122,7 +166,11 @@ static bool qt_event_filter(void *message, long *result)
 
 static int startup_main(int &argc, char **argv, MUtils::Startup::main_function_t *const entry_point, const char* const appName, const bool &debugConsole)
 {
-	qInstallMsgHandler(qt_message_handler);
+#if QT_VERSION >= 0x050000
+	qInstallMessageHandler(qt_message_handler);
+#else
+    qInstallMsgHandler(qt_message_handler);
+#endif
 	MUtils::Terminal::setup(argc, argv, appName, MUTILS_DEBUG || debugConsole);
 	return entry_point(argc, argv);
 }
@@ -229,7 +277,7 @@ QApplication *MUtils::Startup::create_qt(int &argc, char **argv, const QString &
 	//Check Qt version
 #ifdef QT_BUILD_KEY
 	qDebug("Using Qt v%s [%s], %s, %s", qVersion(), QLibraryInfo::buildDate().toString(Qt::ISODate).toLatin1().constData(), (qSharedBuild() ? "DLL" : "Static"), QLibraryInfo::buildKey().toLatin1().constData());
-	qDebug("Compiled with Qt v%s [%s], %s\n", QT_VERSION_STR, QT_PACKAGEDATE_STR, QT_BUILD_KEY);
+	qDebug("Compiled with Qt v%s, %s\n", QT_VERSION_STR, QT_BUILD_KEY);
 	if(_stricmp(qVersion(), QT_VERSION_STR))
 	{
 		qFatal("%s", QApplication::tr("Executable '%1' requires Qt v%2, but found Qt v%3.").arg(executableName, QString::fromLatin1(QT_VERSION_STR), QString::fromLatin1(qVersion())).toLatin1().constData());
@@ -242,7 +290,7 @@ QApplication *MUtils::Startup::create_qt(int &argc, char **argv, const QString &
 	}
 #else
 	qDebug("Using Qt v%s [%s], %s", qVersion(), QLibraryInfo::buildDate().toString(Qt::ISODate).toLatin1().constData(), (qSharedBuild() ? "DLL" : "Static"));
-	qDebug("Compiled with Qt v%s [%s]\n", QT_VERSION_STR, QT_PACKAGEDATE_STR);
+	qDebug("Compiled with Qt v%s\n", QT_VERSION_STR);
 #endif
 
 	//Check the Windows version
@@ -298,7 +346,12 @@ QApplication *MUtils::Startup::create_qt(int &argc, char **argv, const QString &
 	application->setApplicationName(appName);
 	application->setOrganizationName("LoRd_MuldeR");
 	application->setOrganizationDomain("mulder.at.gg");
+#if QT_VERSION >= 0x050000
+    MUtils::Startup::Internal::NativeEventFilter filter;
+    application->installNativeEventFilter(&filter);
+#else
 	application->setEventFilter(qt_event_filter);
+#endif
 
 	//Check for supported image formats
 	QList<QByteArray> supportedFormats = QImageReader::supportedImageFormats();

--- a/src/Taskbar7_Win32.cpp
+++ b/src/Taskbar7_Win32.cpp
@@ -164,13 +164,13 @@ bool MUtils::Taskbar7::setOverlayIcon(const QIcon *const icon, const QString &in
 	{
 		if(const HICON hIcon = pixmapToHICON(icon->pixmap(16,16)))
 		{
-			result = p->taskbarList->SetOverlayIcon(m_window->winId(), hIcon, MUTILS_WCHR(info));
+			result = p->taskbarList->SetOverlayIcon(reinterpret_cast<HWND>(m_window->winId()), hIcon, MUTILS_WCHR(info));
 			DestroyIcon(hIcon);
 		}
 	}
 	else
 	{
-		result = p->taskbarList->SetOverlayIcon(m_window->winId(), NULL, MUTILS_WCHR(info));
+		result = p->taskbarList->SetOverlayIcon(reinterpret_cast<HWND>(m_window->winId()), NULL, MUTILS_WCHR(info));
 	}
 	return SUCCEEDED(result);
 }

--- a/src/Taskbar7_Win32.cpp
+++ b/src/Taskbar7_Win32.cpp
@@ -28,6 +28,15 @@
 //Qt
 #include <QWidget>
 #include <QIcon>
+#if QT_VERSION >= 0x050000
+#include <QtWinExtras>
+#endif
+
+#if QT_VERSION >= 0x050000
+#define pixmapToHICON(p) QtWin::toHICON(p)
+#else
+#define pixmapToHICON(p) p.toWinHICON()
+#endif
 
 //Windows includes
 #define NOMINMAX
@@ -153,7 +162,7 @@ bool MUtils::Taskbar7::setOverlayIcon(const QIcon *const icon, const QString &in
 	HRESULT result = HRESULT(-1);
 	if(icon)
 	{
-		if(const HICON hIcon = icon->pixmap(16,16).toWinHICON())
+		if(const HICON hIcon = pixmapToHICON(icon->pixmap(16,16)))
 		{
 			result = p->taskbarList->SetOverlayIcon(m_window->winId(), hIcon, MUTILS_WCHR(info));
 			DestroyIcon(hIcon);

--- a/src/Utils_Win32.cpp
+++ b/src/Utils_Win32.cpp
@@ -55,7 +55,7 @@ uintptr_t MUtils::Win32Utils::qicon_to_hicon(const QIcon &icon, const int w, con
 		QPixmap pixmap = icon.pixmap(w, h);
 		if(!pixmap.isNull())
 		{
-            return (uintptr_t) pixmapToHICON(pixmap);
+			return (uintptr_t) pixmapToHICON(pixmap);
 		}
 	}
 	return NULL;

--- a/src/Utils_Win32.cpp
+++ b/src/Utils_Win32.cpp
@@ -33,6 +33,15 @@
 #include <QReadWriteLock>
 #include <QLibrary>
 #include <QHash>
+#if QT_VERSION >= 0x050000
+#include <QtWinExtras>
+#endif
+
+#if QT_VERSION >= 0x050000
+#define pixmapToHICON(p) QtWin::toHICON(p)
+#else
+#define pixmapToHICON(p) p.toWinHICON()
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // QICON TO HICON
@@ -45,7 +54,7 @@ uintptr_t MUtils::Win32Utils::qicon_to_hicon(const QIcon &icon, const int w, con
 		QPixmap pixmap = icon.pixmap(w, h);
 		if(!pixmap.isNull())
 		{
-			return (uintptr_t) pixmap.toWinHICON();
+            return (uintptr_t) pixmapToHICON(pixmap);
 		}
 	}
 	return NULL;

--- a/src/Utils_Win32.cpp
+++ b/src/Utils_Win32.cpp
@@ -25,6 +25,7 @@
 #ifndef _INC_WINDOWS
 #define WIN32_LEAN_AND_MEAN 1
 #include <Windows.h>
+#include <ObjIdl.h>  // required by QWinMime in QtWinExtras
 #endif //_INC_WINDOWS
 
 //Qt


### PR DESCRIPTION
This is a first attempt at Qt 5 support for MUtilities. Changes are fairly minor, with the exception of commit 8f05782 (Startup.cpp) which adds new Qt 5 event handlers. A similar change will need to be made to replace [qInstallMsgHandler in Main.cpp](https://github.com/lordmulder/MUtilities/blob/master/test/src/Main.cpp#L115) (MUtilitiesTest project).

Additional includes and linker dependencies need to be added to the MSBuild projects for Qt 5:

- $(QTDIR)\include\QtWidgets
- $(QTDIR)\include\QtWinExtras
- $(QTDIR)\lib\Qt5Widgetsd.lib _Debug_
- $(QTDIR)\lib\Qt5WinExtrasd.lib _Debug_
- $(QTDIR)\lib\Qt5Widgets.lib _Release_
- $(QTDIR)\lib\Qt5WinExtras.lib _Release_

I haven't done much testing yet. I am only using the JobObject class in my own project.